### PR TITLE
Preventing ViewModel replacement for application errors without response in MVC events

### DIFF
--- a/src/ZfrRest/Mvc/View/Http/SelectModelListener.php
+++ b/src/ZfrRest/Mvc/View/Http/SelectModelListener.php
@@ -72,7 +72,14 @@ class SelectModelListener extends AbstractListenerAggregate
     public function selectModel(MvcEvent $e)
     {
         $result = $e->getResult();
-        if ($result instanceof ModelInterface || $result instanceof ResponseInterface) {
+
+        // If a view model was already set, or if the application errored with no produced result, no
+        // view model replacement should happen
+        if (
+            $result instanceof ModelInterface
+            || $result instanceof ResponseInterface
+            || (!isset($result) && $e->getError())
+        ) {
             return;
         }
 

--- a/tests/ZfrRestTest/Mvc/View/Http/SelectModelListenerTest.php
+++ b/tests/ZfrRestTest/Mvc/View/Http/SelectModelListenerTest.php
@@ -134,4 +134,15 @@ class SelectModelListenerTest extends TestCase
             $this->assertTrue($this->event->propagationIsStopped());
         }
     }
+
+    public function testDoesNotInterceptErrorApplicationResponse()
+    {
+        // typical application scenario - no result and the application has exited
+        $this->event->setError('application-hates-you');
+        $this->event->setResult(null);
+
+        $this->selectModelListener->selectModel($this->event);
+
+        $this->assertNull($this->event->getResult());
+    }
 }


### PR DESCRIPTION
The problem here is basically that any application error (even 404s) were producing `[]` as output because the view model was being set even in such a faulty case
