### PR TITLE
Add wildcard header to the viewmodel list, using the standard viewmodel

### DIFF
--- a/src/ZfrRest/View/Model/ModelPluginManager.php
+++ b/src/ZfrRest/View/Model/ModelPluginManager.php
@@ -34,6 +34,7 @@ class ModelPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $invokableClasses = array(
+        '*/*'                    => 'Zend\View\Model\ViewModel',
         'text/html'              => 'Zend\View\Model\ViewModel',
         'application/xhtml+xml'  => 'Zend\View\Model\ViewModel',
         'application/json'       => 'Zend\View\Model\JsonModel',


### PR DESCRIPTION
A default application requiring `*/*` should eventually always retrieve the standard `Zend\View\Model\ViewModel` - this can be arguable, but we can remove it in future or use smarter pattern matching in the `ZfrRest\View\Model\ModelPluginManager` 
