### PR TITLE
Travis should use composer update (instead of install) for dev deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source
+  - composer update --prefer-source
 
 script:
   - phpunit


### PR DESCRIPTION
This should fix the DoctrineORMModule issues as seen in https://travis-ci.org/zf-fr/zfr-rest/jobs/7467431
