### PR TITLE
Convert string boolean to boolean type

### DIFF
--- a/src/ZfrRest/Mvc/Router/Http/ResourceGraphRoute.php
+++ b/src/ZfrRest/Mvc/Router/Http/ResourceGraphRoute.php
@@ -239,6 +239,11 @@ class ResourceGraphRoute implements RouteInterface
 
             foreach ($this->query as $key => $value) {
                 if ($classMetadata->hasField($key)) {
+                    if ($value === 'true') {
+                        $value = true;
+                    } elseif ($value === 'false') {
+                        $value = false;
+                    }
                     $criteria->andWhere(Criteria::expr()->eq($key, $value));
                 }
             }


### PR DESCRIPTION
Imagine a request like this : /resources?valid=true
When you retrieve valid parameter from query its type is string and not boolean. So if you want criteria matching base on boolean you must send /resources?valid=1. I think it's not the beautiful way to do it.
