### PR TITLE
Remove automatic serialization

### DIFF
--- a/src/ZfrRest/Mvc/Controller/AbstractRestfulController.php
+++ b/src/ZfrRest/Mvc/Controller/AbstractRestfulController.php
@@ -60,6 +60,8 @@ class AbstractRestfulController extends AbstractController
     {
         /* @var HttpRequest $request */
         $request = $this->getRequest();
+
+        /* @var \ZfrRest\Mvc\Controller\MethodHandler\MethodHandlerInterface $handler */
         $handler = $this->getMethodHandlerManager()->get($request->getMethod());
 
         /* @var \ZfrRest\Resource\ResourceInterface $resource */

--- a/src/ZfrRest/Mvc/CreateResourceModelListener.php
+++ b/src/ZfrRest/Mvc/CreateResourceModelListener.php
@@ -60,18 +60,12 @@ class CreateResourceModelListener extends AbstractListenerAggregate
         $result   = $event->getResult();
         $resource = $event->getRouteMatch()->getParam('resource');
 
-        // Do nothing if a Model has already been returned, or if we don't have any resource
-        if (($result instanceof ModelInterface) || $result === null || !$resource instanceof ResourceInterface) {
+        // ZfrRest expects an array
+        if (!is_array($result) || !$resource instanceof ResourceInterface) {
             return;
         }
 
-        // Because we may manipulate the resource data in the controller (for instance wrapping a collection around
-        // a paginator), we need to create a new resource from the data
-        if ($result !== $resource->getData()) {
-            $model = new ResourceModel(new Resource($result, $resource->getMetadata()));
-        } else {
-            $model = new ResourceModel($resource);
-        }
+        $model = new ResourceModel($result);
 
         $event->setViewModel($model);
         $event->setResult($model);

--- a/src/ZfrRest/View/Model/ResourceModel.php
+++ b/src/ZfrRest/View/Model/ResourceModel.php
@@ -22,6 +22,8 @@ use Zend\View\Model\ViewModel;
 use ZfrRest\Resource\ResourceInterface;
 
 /**
+ * A resource model holds the data that is rendered
+ *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @licence MIT
  */
@@ -35,29 +37,29 @@ class ResourceModel extends ViewModel
     protected $terminate = true;
 
     /**
-     * The resource to be rendered
+     * The data that is rendered
      *
-     * @var ResourceInterface
+     * @var array
      */
-    protected $resource;
+    protected $data;
 
     /**
      * Constructor
      *
-     * @param ResourceInterface $resource
+     * @param array $data
      */
-    public function __construct(ResourceInterface $resource)
+    public function __construct(array $data)
     {
-        $this->resource = $resource;
+        $this->data = $data;
     }
 
     /**
-     * Get the resource
+     * Get the data to render
      *
-     * @return ResourceInterface
+     * @return array
      */
-    public function getResource()
+    public function getData()
     {
-        return $this->resource;
+        return $this->data;
     }
 }

--- a/src/ZfrRest/View/Renderer/ResourceRenderer.php
+++ b/src/ZfrRest/View/Renderer/ResourceRenderer.php
@@ -46,21 +46,6 @@ class ResourceRenderer implements RendererInterface
     protected $resolver;
 
     /**
-     * @var HydratorPluginManager
-     */
-    protected $hydratorPluginManager;
-
-    /**
-     * Constructor
-     *
-     * @param HydratorPluginManager $hydratorPluginManager
-     */
-    public function __construct(HydratorPluginManager $hydratorPluginManager)
-    {
-        $this->hydratorPluginManager = $hydratorPluginManager;
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function getEngine()
@@ -85,60 +70,6 @@ class ResourceRenderer implements RendererInterface
             return;
         }
 
-        $resource = $nameOrModel->getResource();
-
-        if ($resource->isCollection()) {
-            $collectionMetadata = $resource->getMetadata()->getCollectionMetadata();
-            $hydrator           = $this->hydratorPluginManager->get($collectionMetadata->getHydratorName());
-
-            $payload = $this->renderCollection($resource->getData(), $hydrator);
-        } else {
-            $resourceMetadata = $resource->getMetadata();
-            $hydrator         = $this->hydratorPluginManager->get($resourceMetadata->getHydratorName());
-
-            $payload = $this->renderItem($resource->getData(), $hydrator);
-        }
-
-        return json_encode($payload);
-    }
-
-    /**
-     * Return the payload for a single item
-     *
-     * @param  mixed             $item
-     * @param  HydratorInterface $hydrator
-     * @return array
-     */
-    protected function renderItem($item, HydratorInterface $hydrator)
-    {
-        return $hydrator->extract($item);
-    }
-
-    /**
-     * Return the payload for a collection
-     *
-     * By default, it creates some data if a paginator is found, and wrap all items under the "items" key
-     *
-     * @param  array|Traversable $collection
-     * @param  HydratorInterface $hydrator
-     * @return array
-     */
-    protected function renderCollection($collection, HydratorInterface $hydrator)
-    {
-        $payload = [];
-
-        if ($collection instanceof Paginator) {
-            $payload = [
-                'limit'  => $collection->getItemCountPerPage(),
-                'offset' => ($collection->getCurrentPageNumber() - 1) * $collection->getItemCountPerPage(),
-                'total'  => $collection->getTotalItemCount()
-            ];
-        }
-
-        foreach ($collection as $item) {
-            $payload['items'][] = $this->renderItem($item, $hydrator);
-        }
-
-        return $payload;
+        return json_encode($nameOrModel->getData());
     }
 }

--- a/tests/ZfrRestTest/Mvc/CreateResourceModelListenerTest.php
+++ b/tests/ZfrRestTest/Mvc/CreateResourceModelListenerTest.php
@@ -87,11 +87,12 @@ class CreateResourceModelListenerTest extends PHPUnit_Framework_TestCase
         $this->assertNull($this->createResourceModelListener->createResourceModel($event));
     }
 
-    public function testCreateResourceModelFromSingleResource()
+    public function testCreateResourceModelFromArray()
     {
-        $data     = new \stdClass();
+        $data     = ['foo' => 'bar'];
+        $metadata = $this->getMock('ZfrRest\Resource\Metadata\ResourceMetadataInterface');
         $resource = $this->getMock('ZfrRest\Resource\ResourceInterface');
-        $resource->expects($this->once())->method('getData')->will($this->returnValue($data));
+        $resource->expects($this->once())->method('getMetadata')->will($this->returnValue($metadata));
 
         $event      = new MvcEvent();
         $routeMatch = new RouteMatch(['resource' => $resource]);
@@ -104,34 +105,5 @@ class CreateResourceModelListenerTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('ZfrRest\View\Model\ResourceModel', $event->getResult());
 
         $this->assertSame($resource, $event->getResult()->getResource());
-    }
-
-    public function testCreateNewResourceIfResultIsDifferentFromOriginalResource()
-    {
-        $originalData = $this->getMock('Doctrine\Common\Collections\ArrayCollection');
-        $returnedData = $this->getMock('Zend\Paginator\Paginator', [], [], '', false);
-
-        $resource = $this->getMock('ZfrRest\Resource\ResourceInterface');
-        $resource->expects($this->once())->method('getData')->will($this->returnValue($originalData));
-
-        $metadata      = $this->getMock('ZfrRest\Resource\Metadata\ResourceMetadataInterface');
-        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
-
-        $resource->expects($this->once())->method('getMetadata')->will($this->returnValue($metadata));
-        $metadata->expects($this->once())->method('getClassMetadata')->will($this->returnValue($classMetadata));
-
-        $event      = new MvcEvent();
-        $routeMatch = new RouteMatch(['resource' => $resource]);
-        $event->setResult($returnedData);
-        $event->setRouteMatch($routeMatch);
-
-        $this->createResourceModelListener->createResourceModel($event);
-
-        $this->assertInstanceOf('ZfrRest\View\Model\ResourceModel', $event->getViewModel());
-        $this->assertInstanceOf('ZfrRest\View\Model\ResourceModel', $event->getResult());
-        $this->assertInstanceOf('Zend\Paginator\Paginator', $event->getResult()->getResource()->getData());
-
-        $this->assertNotSame($resource, $event->getResult()->getResource());
-        $this->assertSame($metadata, $event->getResult()->getResource()->getMetadata());
     }
 }


### PR DESCRIPTION
Hi,

ping @Ocramius @danizord

As discussed with @danizord, there are two main problems with the current automatic serialization. For remind, the current way is either directly returns the entity (for instance a User) or a paginator. The ResourceRenderer then automatically use the hydrator to extract data, or add metadata if it detects a paginator was found.

This has two problems:
- It's hard to customize the way the output is serialized. For instance you may want to have underscore_separated keys, and wrapping all the items inside a "items" key in the payload.
- You may want to add other data that are computed and actually don't belong to the entity itself. For instance, the GitHub API (https://api.github.com/users/danizord) adds data like "public_repos" that don't really belong to the entity itself (I suppose those are fetched from a repository and added to the payload). Because the hydrator is used, it makes it nearly impossible.

Therefore, albeit convenient, all this automation is hard to use in a lot of cases. This PR completely removes any automation, so the serialization has to be done in the controller directly:

``` php
public function get(User $user)
{
    return ['username' => $user->getUsername()]; // ...
}
```

Note that this solution is far from optimal, because now everything has to be done manually. Furthermore, a lot of duplication is done (there is great chance that the "get" method of the UsersCollectionController will do the same thing).
