### PR TITLE
Remove hydrator mapping for Collection

### DIFF
--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -84,8 +84,7 @@ use ZfrRest\Resource\Metadata\Annotation as REST;
  *      hydrator="Zend\Stdlib\Hydrator\ClassMethods"
  * )
  * @REST\Collection(
- *      controller="Application\Controller\UsersController",
- *      hydrator="Zend\Stdlib\Hydrator\ClassMethods"
+ *      controller="Application\Controller\UsersController"
  * )
  */
 class User
@@ -246,7 +245,7 @@ to do is **passing the resource to the service for your business logic**.
 
 For the `put` method, you don't even need to manually validate the user data, because it has already been validated
 using the input filter you specified in the mapping. If data would have been invalid, it would have returned a
-400 Bad Request error, with the various error messages under the `errors` key.
+`422 Unprocessable Entity` error, with the various error messages under the `errors` key.
 
 If you want automatic serialization of the resource, you must return a ResourceModel (it needs a resource). ZfrRest
 provides you a utility controller plugin called `resourceModel` that you can use to create one.
@@ -361,8 +360,7 @@ use ZfrRest\Resource\Metadata\Annotation as REST;
  *      hydrator="Zend\Stdlib\Hydrator\ClassMethods"
  * )
  * @REST\Collection(
- *      controller="Application\Controller\TweetsController",
- *      hydrator="Zend\Stdlib\Hydrator\ClassMethods"
+ *      controller="Application\Controller\TweetsController"
  * )
  */
 class Tweet

--- a/docs/08. Mapping reference.md
+++ b/docs/08. Mapping reference.md
@@ -25,7 +25,6 @@ Allow to define mapping when a resource is accessed as a collection.
 Attributes:
 
 * `controller`: FQCN of the controller (pulled from the controller plugin manager)
-* `hydrator`: FQCN of the hydrator (pulled from the hydrator plugin manager).
 
 ### Association
 

--- a/src/ZfrRest/Resource/Metadata/Annotation/Collection.php
+++ b/src/ZfrRest/Resource/Metadata/Annotation/Collection.php
@@ -30,18 +30,12 @@ final class Collection implements AnnotationInterface
     public $controller;
 
     /**
-     * @var string
-     */
-    public $hydrator;
-
-    /**
      * {@inheritDoc}
      */
     public function getValue()
     {
         return [
-            'controller'  => $this->controller,
-            'hydrator'    => $this->hydrator
+            'controller' => $this->controller
         ];
     }
 }

--- a/src/ZfrRest/Resource/Metadata/CollectionResourceMetadata.php
+++ b/src/ZfrRest/Resource/Metadata/CollectionResourceMetadata.php
@@ -33,12 +33,4 @@ class CollectionResourceMetadata extends ClassMetadata implements CollectionReso
     {
         return $this->propertyMetadata['controller'];
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getHydratorName()
-    {
-        return $this->propertyMetadata['hydrator'];
-    }
 }

--- a/src/ZfrRest/Resource/Metadata/CollectionResourceMetadataInterface.php
+++ b/src/ZfrRest/Resource/Metadata/CollectionResourceMetadataInterface.php
@@ -32,11 +32,4 @@ interface CollectionResourceMetadataInterface
      * @return string|null
      */
     public function getControllerName();
-
-    /**
-     * Get the hydrator's FQCN to be used for this resource
-     *
-     * @return string|null
-     */
-    public function getHydratorName();
 }

--- a/src/ZfrRest/View/Renderer/SimpleResourceRenderer.php
+++ b/src/ZfrRest/View/Renderer/SimpleResourceRenderer.php
@@ -121,7 +121,7 @@ class SimpleResourceRenderer extends AbstractResourceRenderer
      */
     public function renderCollection(ResourceInterface $resource)
     {
-        $hydratorName = $resource->getMetadata()->getCollectionMetadata()->getHydratorName();
+        $hydratorName = $resource->getMetadata()->getHydratorName();
         $hydrator     = $this->hydratorPluginManager->get($hydratorName);
 
         $data    = $resource->getData();

--- a/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/A.php
+++ b/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/A.php
@@ -29,8 +29,7 @@ use ZfrRest\Resource\Metadata\Annotation as REST;
  *      hydrator="ResourceHydrator"
  * )
  * @REST\Collection(
- *      controller="CollectionController",
- *      hydrator="CollectionHydrator"
+ *      controller="CollectionController"
  * )
  */
 class A

--- a/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/B.php
+++ b/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/B.php
@@ -31,8 +31,7 @@ use Doctrine\ORM\Mapping as ORM;
  *      hydrator="ResourceHydrator"
  * )
  * @REST\Collection(
- *      controller="CollectionController",
- *      hydrator="CollectionHydrator"
+ *      controller="CollectionController"
  * )
  */
 class B

--- a/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/C.php
+++ b/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/C.php
@@ -31,8 +31,7 @@ use Doctrine\ORM\Mapping as ORM;
  *      hydrator="ResourceHydrator"
  * )
  * @REST\Collection(
- *      controller="CollectionController",
- *      hydrator="CollectionHydrator"
+ *      controller="CollectionController"
  * )
  */
 class C

--- a/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/D.php
+++ b/tests/ZfrRestTest/Asset/Resource/Metadata/Annotation/D.php
@@ -29,8 +29,7 @@ use ZfrRest\Resource\Metadata\Annotation as REST;
  *      hydrator="ResourceHydrator"
  * )
  * @REST\Collection(
- *      controller="CollectionController",
- *      hydrator="CollectionHydrator"
+ *      controller="CollectionController"
  * )
  */
 class D

--- a/tests/ZfrRestTest/Resource/Metadata/Annotation/CollectionTest.php
+++ b/tests/ZfrRestTest/Resource/Metadata/Annotation/CollectionTest.php
@@ -33,12 +33,10 @@ class CollectionTest extends PHPUnit_Framework_TestCase
     public function testAnnotation()
     {
         $annotation = new Collection();
-        $annotation->controller  = 'Controller';
-        $annotation->hydrator    = 'Hydrator';
+        $annotation->controller = 'Controller';
 
         $expected = [
-            'controller'  => 'Controller',
-            'hydrator'    => 'Hydrator'
+            'controller' => 'Controller'
         ];
 
         $this->assertEquals($expected, $annotation->getValue());

--- a/tests/ZfrRestTest/Resource/Metadata/CollectionResourceMetadataTest.php
+++ b/tests/ZfrRestTest/Resource/Metadata/CollectionResourceMetadataTest.php
@@ -35,8 +35,7 @@ class ResourceTest extends PHPUnit_Framework_TestCase
         $collectionResourceMetadata = new CollectionResourceMetadata('stdClass');
 
         $data = [
-            'controller' => 'Controller',
-            'hydrator'   => 'Hydrator'
+            'controller' => 'Controller'
         ];
 
         foreach ($data as $key => $value) {
@@ -44,6 +43,5 @@ class ResourceTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals($data['controller'], $collectionResourceMetadata->getControllerName());
-        $this->assertEquals($data['hydrator'], $collectionResourceMetadata->getHydratorName());
     }
 }

--- a/tests/ZfrRestTest/Resource/Metadata/Driver/AnnotationDriverTest.php
+++ b/tests/ZfrRestTest/Resource/Metadata/Driver/AnnotationDriverTest.php
@@ -46,7 +46,6 @@ class AnnotationDriverTest extends PHPUnit_Framework_TestCase
 
         $collectionMetadata = $metadata->getCollectionMetadata();
         $this->assertEquals('CollectionController', $collectionMetadata->getControllerName());
-        $this->assertEquals('CollectionHydrator', $collectionMetadata->getHydratorName());
 
         $this->assertTrue($metadata->hasAssociationMetadata('b'));
         $this->assertFalse($metadata->hasAssociationMetadata('c'));

--- a/tests/ZfrRestTest/View/Renderer/SimpleResourceRendererTest.php
+++ b/tests/ZfrRestTest/View/Renderer/SimpleResourceRendererTest.php
@@ -31,7 +31,7 @@ use ZfrRest\View\Renderer\SimpleResourceRenderer;
  * @group Coverage
  * @covers \ZfrRest\View\Renderer\SimpleResourceRenderer
  */
-class ResourceRendererTest extends PHPUnit_Framework_TestCase
+class SimpleResourceRendererTest extends PHPUnit_Framework_TestCase
 {
     /**
      * ResourceRenderer does not really have engine
@@ -90,11 +90,10 @@ class ResourceRendererTest extends PHPUnit_Framework_TestCase
     {
         $hydratorPluginManager = $this->getMock('Zend\Stdlib\Hydrator\HydratorPluginManager');
 
-        $renderer           = new SimpleResourceRenderer($hydratorPluginManager);
-        $resource           = $this->getMock('ZfrRest\Resource\ResourceInterface');
-        $metadata           = $this->getMock('ZfrRest\Resource\Metadata\ResourceMetadataInterface');
-        $collectionMetadata = $this->getMock('ZfrRest\Resource\Metadata\CollectionResourceMetadataInterface');
-        $hydrator           = $this->getMock('Zend\Stdlib\Hydrator\HydratorInterface');
+        $renderer = new SimpleResourceRenderer($hydratorPluginManager);
+        $resource = $this->getMock('ZfrRest\Resource\ResourceInterface');
+        $metadata = $this->getMock('ZfrRest\Resource\Metadata\ResourceMetadataInterface');
+        $hydrator = $this->getMock('Zend\Stdlib\Hydrator\HydratorInterface');
 
         $resourceModel = new ResourceModel($resource, $hydrator);
         $paginator     = $this->getMock('Zend\Paginator\Paginator', [], [], '', false);
@@ -123,8 +122,7 @@ class ResourceRendererTest extends PHPUnit_Framework_TestCase
         $resource->expects($this->once())->method('getMetadata')->will($this->returnValue($metadata));
         $resource->expects($this->once())->method('getData')->will($this->returnValue($paginator));
 
-        $metadata->expects($this->once())->method('getCollectionMetadata')->will($this->returnValue($collectionMetadata));
-        $collectionMetadata->expects($this->once())->method('getHydratorName')->will($this->returnValue('Hydrator'));
+        $metadata->expects($this->once())->method('getHydratorName')->will($this->returnValue('Hydrator'));
 
         $hydratorPluginManager->expects($this->once())
                               ->method('get')


### PR DESCRIPTION
ping @danizord

This PR removes the Hydrator mapping in the @REST\Collection mapping. The reason is that it was confusing as hell. My idea with this feature was to provide a clean way to allow to serialize an entity differently if we hit /users or /users/1 (for instance to provide more details when fetching a specific entity). However, I now think this is a bad idea (especially if you have pagination, there is few reason to shrink the response).

But the biggest problem is that, as of today, the collection hydrator was only used in the renderer. For instance, when hitting POST /users, you actually reach the mapping defined in the collection part, BUT you are actually creating a SINGLE user inside a context of a COLLECTION. So the Post handler was using... the hydrator defined in the "Resource" annotation. So this was a bit counter-intuitive and found it very confusing to use and can lead to very strange results.

So, as I did for input filter, for now I prefer to remove the hydrator from collection mapping, and only keep the "controller" value. This is much cleaner, and does not force you to add a hydrator annotation each time (99% of the time it's the same as in the Resource annotation).

We can always add this feature later, but as it is implemented today, it's wrong.
