### PR TITLE
Properly take into account routable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.2
+
+* `routable` metadata is now correctly taken into account by the router, so it won't route to the associated
+resource if the parameter is set to false.
+
 ## 0.2.1
 
 * HttpExceptionListener now stops propagation if it can handle a specific exception.

--- a/src/ZfrRest/Router/Http/Matcher/AssociationSubPathMatcher.php
+++ b/src/ZfrRest/Router/Http/Matcher/AssociationSubPathMatcher.php
@@ -63,10 +63,16 @@ class AssociationSubPathMatcher implements SubPathMatcherInterface
             return null;
         }
 
+        // We first need to check if the association is routable
+        $associationMetadata = $resourceMetadata->getAssociationMetadata($associationPath);
+
+        if (!isset($associationMetadata['routable']) || !$associationMetadata['routable']) {
+            return null;
+        }
+
         // User may specify a different path for a given association, however we need to retrieve the real
         // property name to be used by Doctrine, so we use the association metadata
-        $associationMetadata = $resourceMetadata->getAssociationMetadata($associationPath);
-        $associationName     = $associationMetadata['propertyName'];
+        $associationName = $associationMetadata['propertyName'];
 
         $classMetadata               = $resourceMetadata->getClassMetadata();
         $associationTargetClass      = $classMetadata->getAssociationTargetClass($associationName);

--- a/tests/ZfrRestTest/Router/Http/Matcher/AssociationSubPathMatcherTest.php
+++ b/tests/ZfrRestTest/Router/Http/Matcher/AssociationSubPathMatcherTest.php
@@ -128,6 +128,7 @@ class AssociationSubPathMatcherTest extends PHPUnit_Framework_TestCase
                  ->method('getAssociationMetadata')
                  ->with($associationPath)
                  ->will($this->returnValue([
+                    'routable'     => true,
                     'propertyName' => $propertyName,
                     'path'         => $associationPath
                 ]));
@@ -159,5 +160,24 @@ class AssociationSubPathMatcherTest extends PHPUnit_Framework_TestCase
         $this->assertSame($associationMetadata, $result->getMatchedResource()->getMetadata());
         $this->assertEquals($associationPath, $result->getMatchedPath());
         $this->assertNull($result->getPreviousMatch());
+    }
+
+    public function testWontMatchWhenRoutableIsSetToFalse()
+    {
+        $resource = $this->getMock('ZfrRest\Resource\ResourceInterface');
+        $metadata = $this->getMock('ZfrRest\Resource\Metadata\ResourceMetadataInterface');
+
+        $resource->expects($this->once())->method('getMetadata')->will($this->returnValue($metadata));
+        $metadata->expects($this->once())
+                 ->method('hasAssociationMetadata')
+                 ->with('bar')
+                 ->will($this->returnValue(true));
+
+        $metadata->expects($this->once())
+                 ->method('getAssociationMetadata')
+                 ->with('bar')
+                 ->will($this->returnValue(['routable' => false]));
+
+        $this->assertNull($this->associationMatcher->matchSubPath($resource, 'bar'));
     }
 }


### PR DESCRIPTION
I've added the routable property in 0.2, but I actually forgot to update the router so that it rejects associations if routable is not defined or set to false. This fixes that.
