### PR TITLE
Allow to pass resource as context to input filter

### DIFF
--- a/src/ZfrRest/Mvc/Controller/MethodHandler/DataValidationTrait.php
+++ b/src/ZfrRest/Mvc/Controller/MethodHandler/DataValidationTrait.php
@@ -57,7 +57,9 @@ trait DataValidationTrait
         $inputFilter = $controller->getInputFilter($this->inputFilterPluginManager, $inputFilterName);
         $inputFilter->setData($data);
 
-        if (!$inputFilter->isValid()) {
+        $validationContext = $resource->getData();
+
+        if (!$inputFilter->isValid($validationContext)) {
             throw new UnprocessableEntityException(
                 'Validation error',
                 $this->formatErrorMessages($inputFilter->getMessages())

--- a/tests/ZfrRestTest/Mvc/Controller/MethodHandler/DataValidationTraitTest.php
+++ b/tests/ZfrRestTest/Mvc/Controller/MethodHandler/DataValidationTraitTest.php
@@ -66,7 +66,9 @@ class DataValidationTraitTest extends PHPUnit_Framework_TestCase
     {
         $resource = $this->getMock('ZfrRest\Resource\ResourceInterface');
         $metadata = $this->getMock('ZfrRest\Resource\Metadata\ResourceMetadataInterface');
+        $context  = new \stdClass;
 
+        $resource->expects($this->once())->method('getData')->will($this->returnValue($context));
         $resource->expects($this->once())->method('getMetadata')->will($this->returnValue($metadata));
         $metadata->expects($this->once())->method('getInputFilterName')->will($this->returnValue('inputFilter'));
 
@@ -76,6 +78,7 @@ class DataValidationTraitTest extends PHPUnit_Framework_TestCase
         $inputFilter->expects($this->once())->method('setData')->with($data);
         $inputFilter->expects($this->once())
                     ->method('isValid')
+                    ->with($context)
                     ->will($this->returnValue(true));
 
         $inputFilter->expects($this->once())


### PR DESCRIPTION
Hi,

This is the associated PR to https://github.com/zendframework/zf2/pull/6154 and https://github.com/doctrine/DoctrineModule/pull/406

It allows to implement things like an update form that has a field that must be unique (email). Because ZfrRest directly fetches an entity, having this entity as context allows to such validators to work.

ping @danizord
