### PR TITLE
Don't prevent plugin usage

### DIFF
--- a/src/ZfrRest/Mvc/Controller/Plugin/ResourceModel.php
+++ b/src/ZfrRest/Mvc/Controller/Plugin/ResourceModel.php
@@ -49,7 +49,7 @@ class ResourceModel extends AbstractPlugin
      */
     public function __invoke($data, ResourceMetadataInterface $resourceMetadata = null)
     {
-        if (!$this->controller instanceof AbstractRestfulController) {
+        if (null === $resourceMetadata && !$this->controller instanceof AbstractRestfulController) {
             throw new RuntimeException(
                 'You tried to use the ResourceModel controller plugin on a controller instance that does
                  not extend "ZfrRest\Mvc\Controller\AbstractRestfulController"'


### PR DESCRIPTION
I'd like to use resource rendering in other controllers than AbstractRestfulController. Therefore the exception is now only thrown if no metadata is explicitly given. Otherwise it can still work!
