### PR TITLE
Allow for metadata in response

### DIFF
--- a/src/ZfrRest/View/Renderer/DefaultResourceRenderer.php
+++ b/src/ZfrRest/View/Renderer/DefaultResourceRenderer.php
@@ -169,6 +169,20 @@ class DefaultResourceRenderer extends AbstractResourceRenderer
      */
     protected function renderItem($object, ResourceMetadataInterface $resourceMetadata)
     {
+        if (is_array($object)) {
+            $result = [];
+
+            foreach ($object as $prop => $value) {
+                if (is_object($value)) {
+                    $result[$prop] = $this->renderItem($value, $resourceMetadata);
+                } else {
+                    $result[$prop] = $value;
+                }
+            }
+
+            return $result;
+        }
+        
         /** @var \Zend\Stdlib\Hydrator\HydratorInterface $hydrator */
         $hydrator = $this->hydratorPluginManager->get($resourceMetadata->getHydratorName());
 


### PR DESCRIPTION
Allows for returning metadata in the response.

```php
class ExampleObject
{
   protected $name = 'el awesome';

   protected $coordinate = '11,11';
}
```

```http
GET /example-objects?coordinate=10,10&distance=100 HTTP/1.1
```

```json
{
   "data": [
        { "0": {
             "name": "el awesome",
             "coordinate": "11,11"
          },
          "distance": 1337
       }
   ]
}
```