### PR TITLE
New controller plugin, computeAlteredInputs

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -16,12 +16,14 @@
  * and is licensed under the MIT license.
  */
 
+use ZfrRest\Factory\ComputeAlteredInputsPluginFactory;
 use ZfrRest\Factory\HttpExceptionListenerFactory;
 use ZfrRest\Factory\HydrateObjectPluginFactory;
 use ZfrRest\Factory\ModuleOptionsFactory;
 use ZfrRest\Factory\ResourceRendererFactory;
 use ZfrRest\Factory\ResourceStrategyFactory;
 use ZfrRest\Factory\ValidateIncomingDataPluginFactory;
+use ZfrRest\Mvc\Controller\Plugin\ComputeAlteredInputs;
 use ZfrRest\Mvc\Controller\Plugin\HydrateObject;
 use ZfrRest\Mvc\Controller\Plugin\ValidateIncomingData;
 use ZfrRest\Mvc\HttpExceptionListener;
@@ -48,11 +50,13 @@ return [
 
     'controller_plugins' => [
         'factories' => [
+            ComputeAlteredInputs::class => ComputeAlteredInputsPluginFactory::class,
             ValidateIncomingData::class => ValidateIncomingDataPluginFactory::class,
-            HydrateObject::class          => HydrateObjectPluginFactory::class
+            HydrateObject::class        => HydrateObjectPluginFactory::class
         ],
 
         'aliases' => [
+            'computeAlteredInputs' => ComputeAlteredInputs::class,
             'validateIncomingData' => ValidateIncomingData::class,
             'hydrateObject'        => HydrateObject::class
         ]

--- a/src/Factory/ComputeAlteredInputsPluginFactory.php
+++ b/src/Factory/ComputeAlteredInputsPluginFactory.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrRest\Factory;
+
+use ZfrRest\Mvc\Controller\Plugin\ComputeAlteredInputs;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @author  Kristofer Karlsson <karlsson.kristofer@gmail.com>
+ * @licence MIT
+ */
+class ComputeAlteredInputsPluginFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        /**
+         * @var \Zend\InputFilter\InputFilterPluginManager $inputFilterPluginManager
+         * @var \Zend\Mvc\Controller\PluginManager         $serviceLocator
+         * @var \Zend\ServiceManager\ServiceManager        $serviceManager
+         */
+        $serviceManager           = $serviceLocator->getServiceLocator();
+        $inputFilterPluginManager = $serviceManager->get('InputFilterManager');
+
+        return new ComputeAlteredInputs($inputFilterPluginManager);
+    }
+}

--- a/src/Mvc/Controller/AbstractRestfulController.php
+++ b/src/Mvc/Controller/AbstractRestfulController.php
@@ -35,6 +35,7 @@ use ZfrRest\Http\Exception\Client\MethodNotAllowedException;
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @licence MIT
  *
+ * @method array computeAlteredInputs($inputFilterName, object $object)
  * @method array validateIncomingData($inputFilterName, array $validationGroup = [])
  * @method object hydrateObject($hydratorName, $object, array $values)
  */

--- a/src/Mvc/Controller/Plugin/ComputeAlteredInputs.php
+++ b/src/Mvc/Controller/Plugin/ComputeAlteredInputs.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace ZfrRest\Mvc\Controller\Plugin;
+
+use Zend\InputFilter\InputFilterPluginManager;
+use Zend\Mvc\Controller\Plugin\AbstractPlugin;
+use ZfrRest\Http\Exception\Client\UnprocessableEntityException;
+
+/**
+ * @author  Kristofer Karlsson <karlsson.kristofer@gmail.com>
+ * @licence MIT
+ */
+class ComputeAlteredInputs extends AbstractPlugin
+{
+    /**
+     * @var InputFilterPluginManager
+     */
+    private $inputFilterPluginManager;
+
+    /**
+     * @param InputFilterPluginManager $inputFilterPluginManager
+     */
+    public function __construct(InputFilterPluginManager $inputFilterPluginManager)
+    {
+        $this->inputFilterPluginManager = $inputFilterPluginManager;
+    }
+
+    /**
+     * Compute altered inputs from incoming data
+     *
+     * @param  string $inputFilterName
+     * @param  object $object
+     *
+     * @return array
+     * @throws UnprocessableEntityException
+     */
+    public function __invoke($inputFilterName, $object)
+    {
+        /** @var \Zend\InputFilter\InputFilterInterface $inputFilter */
+        $inputFilter = $this->inputFilterPluginManager->get($inputFilterName);
+        $data        = json_decode($this->controller->getRequest()->getContent(), true) ?: [];
+        $inputs      = array_keys(array_diff($data, (array)$object));
+
+        foreach ($inputs as $input) {
+            if (!$inputFilter->has($input)) {
+                throw new UnprocessableEntityException('Unrecognized input \'' . $input . '\'');
+            }
+        }
+
+        return $inputs;
+    }
+}


### PR DESCRIPTION
Playing around with the idea of only validating altered fields to stop unique validators from going off if the field wasn't changed (email validator for example).

Thoughts? @bakura10 

```php
/**
 * @param array $params
 *
 * @return ResourceViewModel
 * @throws NotFoundException
 */
public function put(array $params)
{
    $id = (int)$params['id'];

    /** @var $user UserInterface */
    if (!$user = $this->userRepository->findOneBy(['id' => $id])) {
        throw new NotFoundException();
    }

    $validationGroup = $this->computeAlteredInputs(UserInputFilterInterface::class, $user);

    // Only validate and update if we got altered fields
    if (!empty($validationGroup)) {
        $data = $this->validateIncomingData(UserInputFilterInterface::class, $validationGroup);
        $user = $this->hydrateObject(ClassMethods::class, $user, $data);

        $user = $this->userService->update($user);
    }

    return new ResourceViewModel(['user' => $user], ['template' => 'mostad/user']);
}
```