### PR TITLE
Use the new hydrator component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.5.0
+
+* Support for `Zend\Stdlib 2.7` and `Zend\Hydrator`
+
 ## 0.4.5
 
 * Remove automatic 304 Etag as it causes a lot more problems as it solves

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-paginator": "~2.2",
         "zendframework/zend-servicemanager": "~2.2",
         "zendframework/zend-view": "~2.2",
-        "zendframework/zend-stdlib": "~2.2"
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
         "zendframework/zendframework": "~2.2",

--- a/src/Mvc/Controller/Plugin/HydrateObject.php
+++ b/src/Mvc/Controller/Plugin/HydrateObject.php
@@ -18,8 +18,8 @@
 
 namespace ZfrRest\Mvc\Controller\Plugin;
 
+use Zend\Hydrator\HydratorPluginManager;
 use Zend\Mvc\Controller\Plugin\AbstractPlugin;
-use Zend\Stdlib\Hydrator\HydratorPluginManager;
 
 /**
  * @author  Michaël Gallego <mic.gallego@gmail.com>


### PR DESCRIPTION
Since `Zend\Mvc` now create the `Zend\Hydrator\PluginManager` it breaks zfr-rest so this need to be tagged under 0.5.0. 
